### PR TITLE
Listen as HTTPS on IPv6 port 443

### DIFF
--- a/overlay/etc/nginx/sites-available/gitea
+++ b/overlay/etc/nginx/sites-available/gitea
@@ -9,7 +9,7 @@ server {
 }
 
 server {
-	listen [::]:443;
+	listen [::]:443 ssl;
 	listen 0.0.0.0:443 ssl;
 	include /etc/nginx/snippets/ssl.conf;
 	include /etc/nginx/include/gitea-proxy;


### PR DESCRIPTION
Current nginx config listens the port 443 from IPv6 client as HTTP, not as HTTPS.