### PR TITLE
Allow pushing large object over HTTP (again)

### DIFF
--- a/overlay/etc/nginx/include/gitea-proxy
+++ b/overlay/etc/nginx/include/gitea-proxy
@@ -4,6 +4,11 @@ access_log /var/log/nginx/gitea.access.log;
 error_log /var/log/nginx/gitea.error.log;
 
 location / {
+	# `client_max_body_size` directive does not work for named locations
+	# in some versions of nginx, so workaround by specifying here.
+	# See <https://trac.nginx.org/nginx/ticket/2322>.
+	client_max_body_size 0;
+
 	# serve static files from defined root folder;.
 	try_files $uri $uri/index.html $uri.html @gitea;
 }


### PR DESCRIPTION
`client_body_max_size` is added by <https://github.com/turnkeylinux-apps/gitea/pull/7>, but it does not work for named location due to the nginx bug <https://trac.nginx.org/nginx/ticket/2322>.
According to the ticket, at least nginx/1.20.2 and nginx/1.21.6 are affected.

To workaround the issue, specify `client_body_max_size` for non-named location `/`.

Tested with nginx/1.18.0 (turnkey-gitea-17.2-bullseye-amd64) and this change fixes the issue as expected.