### PR TITLE
Turnkey Gitea 18.1 RC1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ and on top of that:
 Gitea Actions - CI/CD "Act" runners
 -----------------------------------
 
-As of TurnKey Gitea v18.0, `Gitea Actions`_ are supported and enabled
+As of TurnKey Gitea v18.1, `Gitea Actions`_ are supported and enabled
 by default. Pre-built `Act runner`_ binaries can be downloaded from Gitea.
 Builds on the Gitea host is supported but discouraged, unless using
 Docker (which requires additional install).

--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+turnkey-gitea-18.1 (1) turnkey; urgency=low
+
+  * Install latest upstream version of Gitea: v1.??.??.
+
+  * Test against TurnKey Linux 18.1
+
 turnkey-gitea-18.0 (1) turnkey; urgency=low
 
   * Install latest upstream version of Gitea: v1.21.10.

--- a/changelog
+++ b/changelog
@@ -1,6 +1,6 @@
 turnkey-gitea-18.1 (1) turnkey; urgency=low
 
-  * Install latest upstream version of Gitea: v1.??.??.
+  * Install latest upstream version of Gitea: v1.25.1.
 
   * Test against TurnKey Linux 18.1
 

--- a/changelog
+++ b/changelog
@@ -1,6 +1,6 @@
 turnkey-gitea-18.1 (1) turnkey; urgency=low
 
-  * Install latest upstream version of Gitea: v1.25.1.
+  * Install latest upstream version of Gitea: v1.25.4.
 
   * Test against TurnKey Linux 18.1
 


### PR DESCRIPTION
# ATTENTION: This is a *TEST* ISO!
**Turnkey Gitea 18.1 RC1**
- Gitea Version 1.25.4

### gitea ➡️ [Test ISO](https://github.com/UncleDan/turnkey-gitea/releases/tag/v18.1-RC1)